### PR TITLE
Revert "Bump org.jetbrains.androidx.navigation:navigation-compose from 2.8.0-alpha11 to 2.9.0-alpha14"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ androidx-core-ktx = "1.15.0"
 compose = "1.7.8"
 compose-plugin = "1.7.3"
 
-androidx-navigation = "2.9.0-alpha14"
+androidx-navigation = "2.8.0-alpha11"
 androidx-lifecycle = "2.8.4"
 
 statelyCommon = "2.1.0"


### PR DESCRIPTION
Reverts santimattius/kmp-compose-gradle-skeleton#119